### PR TITLE
[github-actions]: Upload to GitHub Container Registry using Github Actions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -50,6 +50,6 @@ jobs:
       - name: "Build application Jar"
         run: |
           mvn clean package -DskipTests --file pulsebackend/pom.xml
-          ls backend/target
+          ls pulsebackend/target
           
       

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,5 +51,21 @@ jobs:
         run: |
           mvn --batch-mode clean package -DskipTests --file pulsebackend/pom.xml
           ls pulsebackend/target
-          
-      
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Build pulsebackend Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: . # Keep the context root because Dockerfile handles where the jar is at
+          push: false # false = just build the image for now
+          load: true # load the image in the docker daemon
+          tags: |
+            pulsebackend:latest
+            pulsebackend:${{ github.sha }}
+
+      - name: Verify Docker Image Build
+        run: docker image ls | grep pulsebackend

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: "Build application image"
     needs: tests
     runs-on: ubuntu-latest
-    permissions: # To upload to ghcr: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
+    permissions: # To upload to ghcr using GITHUB_TOKEN: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
       contents: read
       packages: write
       attestations: write

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -63,6 +63,7 @@ jobs:
           context: . # Keep the context root because Dockerfile handles where the jar is at
           push: false # false = just build the image for now
           load: true # load the image in the docker daemon
+          file: {{context}}/pulsebackend/src/main/docker/Dockerfile
           tags: |
             pulsebackend:latest
             pulsebackend:${{ github.sha }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -63,7 +63,7 @@ jobs:
           context: . # Keep the context root because Dockerfile handles where the jar is at
           push: false # false = just build the image for now
           load: true # load the image in the docker daemon
-          file: ${{context}}/pulsebackend/src/main/docker/Dockerfile
+          file: ./pulsebackend/src/main/docker/Dockerfile
           tags: |
             pulsebackend:latest
             pulsebackend:${{ github.sha }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,6 +35,11 @@ jobs:
     name: "Build application image"
     needs: tests
     runs-on: ubuntu-latest
+    permissions: # To upload to ghcr: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: "Checkout code to run on GITHUB_WORKSPACE"
         uses: actions/checkout@v4

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Build application Jar"
         run: |
-          mvn clean package -DskipTests --file backend/pom.xml
+          mvn clean package -DskipTests --file pulsebackend/pom.xml
           ls backend/target
           
       

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    name: "Unit and Integration Tests"
+    name: "CI Tests"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -52,12 +52,12 @@ jobs:
           mvn --batch-mode clean package -DskipTests --file pulsebackend/pom.xml
           ls pulsebackend/target
 
-      - name: Set up Docker Buildx
+      - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
         with:
           version: latest
 
-      - name: Build pulsebackend Docker image
+      - name: "Build pulsebackend Docker image"
         uses: docker/build-push-action@v6
         with:
           context: . # Keep the context root because Dockerfile handles where the jar is at
@@ -67,5 +67,5 @@ jobs:
             pulsebackend:latest
             pulsebackend:${{ github.sha }}
 
-      - name: Verify Docker Image Build
+      - name: "Verify Docker Image Build"
         run: docker image ls | grep pulsebackend

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -82,6 +82,5 @@ jobs:
           file: ./pulsebackend/src/main/docker/Dockerfile
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ghcr.io/${{ github.repository }}/pulsebackend:${{ steps.project.outputs.version }}
-            ghcr.io/${{ github.repository }}/pulsebackend:${{ steps.project.outputs.version }}-sha-${{ github.sha }}
+            ghcr.io/${{ github.repository }}/pulsebackend:sha-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -30,3 +30,26 @@ jobs:
 
       - name: "Run integration tests"
         run: mvn --batch-mode verify --file pulsebackend/pom.xml -Pintegration-tests # run integration tests with profile integration-test defined in pom.xml
+
+  build:
+    name: "Build application image"
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code to run on GITHUB_WORKSPACE"
+        uses: actions/checkout@v4
+
+      # TODO: Maybe find a way to de-duplicate this step
+      - name: "Setup JDK 17"
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "corretto"
+          cache: "maven"
+
+      - name: "Build application Jar"
+        run: |
+          mvn clean package -DskipTests --file backend/pom.xml
+          ls backend/target
+          
+      

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,6 +9,7 @@ on:
       - "pulsebackend/**" # Run when files change in the backend folder only
       - ".github/workflows/backend-ci.yml" # Run when content of backend-ci changes
 
+
 jobs:
   tests:
     name: "CI Tests"
@@ -30,11 +31,15 @@ jobs:
 
       - name: "Run integration tests"
         run: mvn --batch-mode verify --file pulsebackend/pom.xml -Pintegration-tests # run integration tests with profile integration-test defined in pom.xml
-
   build:
     name: "Build application image"
     needs: tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ linux/amd64, linux/arm64]
+
+
     permissions: # To upload to ghcr using GITHUB_TOKEN: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
       contents: read
       packages: write
@@ -84,6 +89,7 @@ jobs:
         with:
           context: . # Keep the context root because Dockerfile handles where the jar is at
           push: true # false = just build the image for now
+          platforms: ${{ matrix.platform }}
           file: ./pulsebackend/src/main/docker/Dockerfile
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -63,7 +63,7 @@ jobs:
           context: . # Keep the context root because Dockerfile handles where the jar is at
           push: false # false = just build the image for now
           load: true # load the image in the docker daemon
-          file: {{context}}/pulsebackend/src/main/docker/Dockerfile
+          file: ${{context}}/pulsebackend/src/main/docker/Dockerfile
           tags: |
             pulsebackend:latest
             pulsebackend:${{ github.sha }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,4 @@
-name: "Continuous Integration Process for Pulse Backend - performing building, linting and testing from multiple contributors (well it's me only for now)"
+name: "Build, Test and Deploy"
 run-name: ${{ github.actor }} is testing out continuous integration in GitHub Actions
 
 on:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    name: "Run Unit and Integration Tests for Pulse Backend"
+    name: "Unit and Integration Tests"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -57,16 +57,31 @@ jobs:
         with:
           version: latest
 
-      - name: "Build pulsebackend Docker image"
+      - name: "Login to GitHub Container Registry"
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Extract metadata for Docker"
+        id: meta # for later use in the below workflows
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/pulsebackend
+          tags: |
+            type=sha,format=short
+            type=ref,event=branch
+            latest
+
+      - name: "Build and Push Docker image to GitHub Container Registry"
         uses: docker/build-push-action@v6
         with:
           context: . # Keep the context root because Dockerfile handles where the jar is at
-          push: false # false = just build the image for now
-          load: true # load the image in the docker daemon
+          push: true # false = just build the image for now
           file: ./pulsebackend/src/main/docker/Dockerfile
           tags: |
-            pulsebackend:latest
-            pulsebackend:${{ github.sha }}
-
-      - name: "Verify Docker Image Build"
-        run: docker image ls | grep pulsebackend
+            ${{ steps.meta.outputs.tags }}
+            ghcr.io/${{ github.repository }}/pulsebackend:${{ steps.project.outputs.version }}
+            ghcr.io/${{ github.repository }}/pulsebackend:${{ steps.project.outputs.version }}-sha-${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Build application Jar"
         run: |
-          mvn clean package -DskipTests --file pulsebackend/pom.xml
+          mvn --batch-mode clean package -DskipTests --file pulsebackend/pom.xml
           ls pulsebackend/target
           
       

--- a/pulsebackend/pom.xml
+++ b/pulsebackend/pom.xml
@@ -37,10 +37,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-mongodb</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>

--- a/pulsebackend/src/main/docker/Dockerfile
+++ b/pulsebackend/src/main/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM amazoncorretto:17
+
+# Set app as current working directory
+WORKDIR /app
+
+COPY pulsebackend/target/*.jar app.jar
+
+USER 1001
+
+ENV JAVA_OPTS=""
+ENV SERVER_PORT=8080
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /app/app.jar"]


### PR DESCRIPTION
This PR demonstrates uploading a docker image to GitHub Container Registry using GitHub Actions:

## Implementation Highlights

- Configured a Job to build the jar, build the docker image for the backend using the jar, add metadata to the image, and upload it to GitHub Container Registry:
  
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/9a2864e3-93d5-46de-ae5d-8e7eede8c799" />

- Version the image using github commit sha

- Build the image for both arm64 and amd64 platform. I was able to pull the image locally using docker and run it:

<img width="1386" alt="image" src="https://github.com/user-attachments/assets/05e62d53-ce54-4f21-9562-4cdab9e29a91" />

## Future Enhancements

- Use app semantic versioning to version the application + use git commit short sha to tag the image in the feature branch
- Create a release when merged to main




